### PR TITLE
Fix form action URL to support sites published under a subpath

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
+- Fix form action URL to support sites published under a subpath
+  [ale-rt]
+
 - Fix redirect to INavigationRoot after impersonate
   [petschki]
 

--- a/src/collective/impersonate/browser/impersonate.pt
+++ b/src/collective/impersonate/browser/impersonate.pt
@@ -11,7 +11,7 @@
         <h5 i18n:translate="impersonate_warning">This is an admin-only form for impersonating other users. Please use it wisely.</h5>
         <br />
 
-        <form method="post" tal:define="errors view/errors | nothing" action="@@impersonate">
+        <form method="post" tal:define="errors view/errors | nothing" action="${request/getURL}">
             <div tal:define="error errors/username | nothing;
                     username request/username | nothing;"
                     tal:attributes="class python: error and 'field error' or 'field'">


### PR DESCRIPTION
If your site URL is https://example.com/intranet and you visit the `@@impersonate` form, it will post to https://example.com/intranet/@@impersonate/@@impersonate

